### PR TITLE
Refine SolarInverterLimiter optional sensor build variants

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -36,7 +36,7 @@ lib_deps =
 	adafruit/Adafruit BusIO@^1.17.4
 	bblanchon/ArduinoJson@7.4.3
 	esphome/ESPAsyncWebServer-esphome@^3.4.0
-	vitaly.ruhl/ESP32 Configuration Manager@^4.0.5
+	vitaly.ruhl/ESP32 Configuration Manager@^4.1.0
 	;symlink://C:/Daten/_Codding/ESP32/ConfigurationsManager
 test_ignore = src/main.cpp
 extra_scripts =
@@ -64,7 +64,7 @@ lib_deps =
 	adafruit/Adafruit BusIO@^1.17.4
 	bblanchon/ArduinoJson@7.4.3
 	esphome/ESPAsyncWebServer-esphome@^3.4.0
-	vitaly.ruhl/ESP32 Configuration Manager@^4.0.5
+	vitaly.ruhl/ESP32 Configuration Manager@^4.1.0
 	;symlink://C:/Daten/_Codding/ESP32/ConfigurationsManager
 test_ignore = src/main.cpp
 extra_scripts =
@@ -76,5 +76,20 @@ upload_flags =
     -a
     otaSI
     -t
-    120
+    30
 
+[env:ota_no_oled]
+extends = env:ota
+build_flags =
+	${env:ota.build_flags}
+	-DFEATURE_OLED_DISPLAY_ENABLED=0
+	-DFEATURE_MQTT_LOGGER_ENABLED=0
+lib_ignore =
+	Adafruit SSD1306
+	Adafruit GFX Library
+
+[env:ota_no_oled_no_bme]
+extends = env:ota_no_oled
+build_flags =
+	${env:ota_no_oled.build_flags}
+	-DFEATURE_BME280_ENABLED=0

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ This project is an ESP32-based solar inverter limiter that can be used to limit 
 - Publishes power and sensor values via MQTT
 - Configurable power output limit
 - Web-based settings UI (ConfigManager)
+- Optional OLED and BME280 sensor support via compile-time feature flags
 
 ## ConfigManager v4 note
 
@@ -50,6 +51,15 @@ Open follow-up:
 2. On first boot (or when WiFi SSID is empty) the device starts an access point:
 3. Connect to the AP and open the web UI (usually `http://192.168.4.1/`) to configure WiFi/MQTT and other settings.
 4. After WiFi is configured the web UI will be available on the device IP in your LAN.
+
+## Build variants
+
+- `usb`: default local build and USB upload workflow.
+- `ota`: OTA build and upload workflow for the full example.
+- `ota_no_oled`: disables the OLED display feature for smaller OTA builds.
+- `ota_no_oled_no_bme`: disables both OLED and BME280 so the example also builds without the I2C sensor/display stack.
+
+When `FEATURE_BME280_ENABLED=0`, the temperature, humidity, and dewpoint runtime values and MQTT topics are omitted. When both OLED and BME280 are disabled, the example also omits the shared I2C settings page.
 
 ## Wiring Diagram
 

--- a/src/Smoother/Smoother.cpp
+++ b/src/Smoother/Smoother.cpp
@@ -1,10 +1,12 @@
 #include "Smoother.h"
 
+#include <new>
+
 Smoother::Smoother(int size)
-  : bufferSize(size > 0 ? size : 1),
+  : bufferSize(clampBufferSize(size)),
     bufferIndex(0)
 {
-  buffer = new int[bufferSize];
+  buffer = new (std::nothrow) int[bufferSize];
   fillBufferOnStart(0);
 }
 
@@ -13,6 +15,10 @@ Smoother::~Smoother() {
 }
 
 void Smoother::fillBufferOnStart(int initialValue) {
+  if (buffer == nullptr || bufferSize <= 0) {
+    return;
+  }
+
   for (int i = 0; i < bufferSize; ++i) {
     buffer[i] = initialValue;
   }
@@ -24,17 +30,27 @@ void Smoother::reset() {
 }
 
 void Smoother::setBufferSize(int size) {
-  if (size <= 0 || size == bufferSize) {
+  const int nextSize = clampBufferSize(size);
+  if (nextSize == bufferSize) {
+    return;
+  }
+
+  int* nextBuffer = new (std::nothrow) int[nextSize];
+  if (nextBuffer == nullptr) {
     return;
   }
 
   delete[] buffer;
-  bufferSize = size;
-  buffer = new int[bufferSize];
+  bufferSize = nextSize;
+  buffer = nextBuffer;
   fillBufferOnStart(0);
 }
 
 int Smoother::smooth(int newValue) {
+  if (buffer == nullptr || bufferSize <= 0) {
+    return newValue;
+  }
+
   buffer[bufferIndex] = newValue;
   bufferIndex = (bufferIndex + 1) % bufferSize;
 
@@ -45,4 +61,22 @@ int Smoother::smooth(int newValue) {
 
   int average = sum / bufferSize;
   return average;
+}
+
+bool Smoother::isReady() const {
+  return buffer != nullptr && bufferSize > 0;
+}
+
+int Smoother::size() const {
+  return bufferSize;
+}
+
+int Smoother::clampBufferSize(int size) {
+  if (size < 1) {
+    return 1;
+  }
+  if (size > MAX_BUFFER_SIZE) {
+    return MAX_BUFFER_SIZE;
+  }
+  return size;
 }

--- a/src/Smoother/Smoother.h
+++ b/src/Smoother/Smoother.h
@@ -2,6 +2,8 @@
 
 class Smoother {
 public:
+  static constexpr int MAX_BUFFER_SIZE = 120;
+
   Smoother(int bufferSize);
   ~Smoother();
 
@@ -10,9 +12,13 @@ public:
   void reset();
 
   void setBufferSize(int size);
+  bool isReady() const;
+  int size() const;
 
 private:
   int* buffer;
   int bufferSize;
   int bufferIndex;
+
+  static int clampBufferSize(int size);
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,12 +3,9 @@
 #include <nvs_flash.h>
 #include <Preferences.h>
 #include <Ticker.h>
-#include <Wire.h>
 #include <WiFi.h>
 #include <time.h>
-#include <BME280_I2C.h>
-#include <Adafruit_GFX.h>
-#include <Adafruit_SSD1306.h>
+#include <new>
 
 #include <AsyncTCP.h>
 #include <ESPAsyncWebServer.h>
@@ -24,11 +21,51 @@
 
 #define CM_MQTT_NO_DEFAULT_HOOKS
 #include "mqtt/MQTTManager.h"
-#include "mqtt/MQTTLogOutput.h"
 
 #include "RS485Module/RS485Module.h"
 #include "helpers/HelperModule.h"
 #include "Smoother/Smoother.h"
+
+// Feature flags
+#ifndef FEATURE_BME280_ENABLED
+#define FEATURE_BME280_ENABLED 1
+#endif
+
+#ifndef FEATURE_OLED_DISPLAY_ENABLED
+#define FEATURE_OLED_DISPLAY_ENABLED 1
+#endif
+
+#ifndef FEATURE_FAN_ENABLED
+#define FEATURE_FAN_ENABLED 0
+#endif
+
+#ifndef FEATURE_HEATER_ENABLED
+#define FEATURE_HEATER_ENABLED 0
+#endif
+
+#ifndef FEATURE_MQTT_LOGGER_ENABLED
+#define FEATURE_MQTT_LOGGER_ENABLED 0
+#endif
+
+#define FEATURE_ANY_I2C (FEATURE_OLED_DISPLAY_ENABLED || FEATURE_BME280_ENABLED)
+#define FEATURE_ANY_RELAY_OUTPUTS (FEATURE_FAN_ENABLED || FEATURE_HEATER_ENABLED)
+
+#if FEATURE_ANY_I2C
+#include <Wire.h>
+#endif
+
+#if FEATURE_BME280_ENABLED
+#include <BME280_I2C.h>
+#endif
+
+#if FEATURE_OLED_DISPLAY_ENABLED
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
+#endif
+
+#if FEATURE_MQTT_LOGGER_ENABLED
+#include "mqtt/MQTTLogOutput.h"
+#endif
 
 #if __has_include("secret/secrets.h")
 #include "secret/secrets.h"
@@ -58,18 +95,8 @@
 #endif
 
 #ifndef VERSION
-#define VERSION "4.2.0"
+#define VERSION "4.3.0"
 #endif
-
-#ifndef FEATURE_FAN_ENABLED
-#define FEATURE_FAN_ENABLED 0
-#endif
-
-#ifndef FEATURE_HEATER_ENABLED
-#define FEATURE_HEATER_ENABLED 0
-#endif
-
-#define FEATURE_ANY_RELAY_OUTPUTS (FEATURE_FAN_ENABLED || FEATURE_HEATER_ENABLED)
 
 enum class NegativePriceSettingPreference : uint8_t
 {
@@ -78,27 +105,21 @@ enum class NegativePriceSettingPreference : uint8_t
     SetZero
 };
 
-// predeclare the functions (prototypes)
-void SetupStartDisplay();
+// Forward declarations
+
+// Startup and lifecycle
 void cb_RS485Listener();
-void testRS232();
-void readBme280();
-void WriteToDisplay();
+#if FEATURE_BME280_ENABLED
+bool readBme280();
 void SetupStartTemperatureMeasuring();
-void ProjectConfig();
-#if FEATURE_FAN_ENABLED
-void CheckVentilator(float currentTemperature);
 #endif
-#if FEATURE_HEATER_ENABLED
-void EvaluateHeater(float currentTemperature);
-#endif
-void ShowDisplayOn();
-void ShowDisplayOff();
-static void logNetworkIpInfo(const char *context);
 void setupGUI();
 void onWiFiConnected();
 void onWiFiDisconnected();
 void onWiFiAPMode();
+
+// Setup helpers
+static void logNetworkIpInfo(const char *context);
 static void setupLogging();
 static void setupMqtt();
 static void setupNetworkDefaults();
@@ -109,25 +130,54 @@ static void configureLimiterSettingsBehavior();
 static void normalizeNegativePriceSettings(NegativePriceSettingPreference preferred, bool persist, bool logCorrection);
 static void registerIOBindings();
 static bool ensureNvsReady();
-static const char *resetReasonToText(esp_reset_reason_t reason);
 static bool isValidMacAddress(const String &value);
 static void applyAccessPointMacPriority();
-static void resetPidController();
-static int computePidStabilizedTarget(int baseTarget, int configuredMin, int configuredMax);
+
+// MQTT and scheduler helpers
+static const char *resetReasonToText(esp_reset_reason_t reason);
 static void updateMqttTopics();
 static void publishMqttNow();
+static void handleRS485Scheduler();
+#if FEATURE_BME280_ENABLED
+static bool handleTemperatureScheduler();
+#endif
 static void updateStatusLED();
-#if FEATURE_FAN_ENABLED
-static void setFanRelay(bool on);
-static bool getFanRelay();
+
+// RS485 and limiter helpers
+void testRS232();
+static void resetPidController();
+static int computePidStabilizedTarget(int baseTarget, int configuredMin, int configuredMax);
+static void processRS485Tick();
+static bool ensurePowerSmoother(int initialValue);
+
+// Display helpers
+#if FEATURE_OLED_DISPLAY_ENABLED
+void SetupStartDisplay();
+void WriteToDisplay();
+void ShowDisplayOn();
+void ShowDisplayOff();
+static void handleDisplayScheduler();
+static void handleDisplayPowerScheduler();
 #endif
-#if FEATURE_HEATER_ENABLED
-static void setHeaterRelay(bool on);
-static bool getHeaterRelay();
-#endif
+
+// Relay automation helpers
 #if FEATURE_ANY_RELAY_OUTPUTS
 static void setManualOverride(bool on);
 #endif
+
+#if FEATURE_FAN_ENABLED
+void CheckVentilator(float currentTemperature);
+static void setFanRelay(bool on);
+static bool getFanRelay();
+#endif
+
+#if FEATURE_HEATER_ENABLED
+void EvaluateHeater(float currentTemperature);
+static void setHeaterRelay(bool on);
+static bool getHeaterRelay();
+#endif
+
+void ProjectConfig();
 //--------------------------------------------------------------------------------------------------------------
 
 #pragma region configuration variables
@@ -165,6 +215,7 @@ struct LimiterSettings
     }
 };
 
+#if FEATURE_BME280_ENABLED
 struct TempSettings
 {
     Config<float> tempCorrection{ConfigOptions<float>{.key = "TCO", .name = "Temperature Correction", .category = "Temp", .defaultValue = 0.1f, .sortOrder = 1}};
@@ -182,22 +233,29 @@ struct TempSettings
         cfg.addSetting(&dewpointRiskWindow);
     }
 };
+#endif
 
+#if FEATURE_ANY_I2C
 struct I2CSettings
 {
     Config<int> sdaPin{ConfigOptions<int>{.key = "I2CSDA", .name = "SDA Pin", .category = "I2C", .defaultValue = 21, .sortOrder = 1}};
     Config<int> sclPin{ConfigOptions<int>{.key = "I2CSCL", .name = "SCL Pin", .category = "I2C", .defaultValue = 22, .sortOrder = 2}};
     Config<int> busFreq{ConfigOptions<int>{.key = "I2CFreq", .name = "Bus Frequency (Hz)", .category = "I2C", .defaultValue = 400000, .sortOrder = 3}};
+#if FEATURE_OLED_DISPLAY_ENABLED
     Config<int> displayAddr{ConfigOptions<int>{.key = "I2CDisp", .name = "Display Address", .category = "I2C", .defaultValue = 0x3C, .sortOrder = 4}};
+#endif
 
     void attachTo(ConfigManagerClass &cfg)
     {
         cfg.addSetting(&sdaPin);
         cfg.addSetting(&sclPin);
         cfg.addSetting(&busFreq);
+#if FEATURE_OLED_DISPLAY_ENABLED
         cfg.addSetting(&displayAddr);
+#endif
     }
 };
+#endif
 
 #if FEATURE_FAN_ENABLED
 struct FanSettings
@@ -231,6 +289,7 @@ struct HeaterSettings
 };
 #endif
 
+#if FEATURE_OLED_DISPLAY_ENABLED
 struct DisplaySettings
 {
     Config<bool> turnDisplayOff{ConfigOptions<bool>{.key = "DispSleep", .name = "Turn Display Off", .category = "Display", .defaultValue = true, .sortOrder = 1}};
@@ -242,6 +301,7 @@ struct DisplaySettings
         cfg.addSetting(&onTimeSec);
     }
 };
+#endif
 
 struct WiFiRoamingSettings
 {
@@ -253,36 +313,98 @@ struct WiFiRoamingSettings
     }
 };
 
-BME280_I2C bme280;
+// Global settings/config instances
+LimiterSettings limiterSettings;
+#if FEATURE_BME280_ENABLED
+TempSettings tempSettings;
+#endif
+#if FEATURE_ANY_I2C
+I2CSettings i2cSettings;
+#endif
+#if FEATURE_FAN_ENABLED
+FanSettings fanSettings;
+#endif
+#if FEATURE_HEATER_ENABLED
+HeaterSettings heaterSettings;
+#endif
+#if FEATURE_OLED_DISPLAY_ENABLED
+DisplaySettings displaySettings;
+#endif
+WiFiRoamingSettings wifiRoamingSettings;
+RS485_Settings rs485settings;
 
+static cm::CoreSettings &coreSettings = cm::CoreSettings::instance();
+static cm::CoreSystemSettings &systemSettings = coreSettings.system;
+static cm::CoreWiFiSettings &wifiSettings = coreSettings.wifi;
+static cm::CoreNtpSettings &ntpSettings = coreSettings.ntp;
+static cm::CoreWiFiServices wifiServices;
+
+// Hardware objects
+#if FEATURE_BME280_ENABLED
+BME280_I2C bme280;
+#endif
+Ticker RS485Ticker;
+
+#if FEATURE_OLED_DISPLAY_ENABLED
 static constexpr int OLED_WIDTH = 128;
 static constexpr int OLED_HEIGHT = 32;
 static constexpr int OLED_RESET_PIN = 4; // keep legacy wiring default
 Adafruit_SSD1306 display(OLED_WIDTH, OLED_HEIGHT, &Wire, OLED_RESET_PIN);
-
-Ticker RS485Ticker;
-Ticker temperatureTicker;
-Ticker displayTicker;
+#endif
 
 Smoother *powerSmoother = nullptr; // there is a memory allocation in setup, better use a pointer here
 
-// global helper variables
-int currentGridImportW = 0; // signed grid power: positive import, negative export
-int inverterCalculatedValue = 0; // calculated controller output before final send decision
-int inverterSetValue = 0;        // value sent to RS485 (with offset and min-max, or max when limiter off)
-int solarPowerW = 0;        // current solar production
-bool negativePriceActive = false; // MQTT input: true forces minimum output when enabled
+// MQTT and runtime state
+int currentGridImportW = 0;        // signed grid power: positive import, negative export
+int inverterCalculatedValue = 0;   // calculated controller output before final send decision
+int inverterSetValue = 0;          // value sent to RS485 (with offset and min-max, or max when limiter off)
+int solarPowerW = 0;               // current solar production
+bool negativePriceActive = false;  // MQTT input: true forces minimum output when enabled
 float electricityPriceEurKwh = 0.0f; // optional MQTT input for status/logging
-float temperature = 0.0;    // current temperature in Celsius
-float Dewpoint = 0.0;       // current dewpoint in Celsius
-float Humidity = 0.0;       // current humidity in percent
-float Pressure = 0.0;       // current pressure in hPa
+#if FEATURE_BME280_ENABLED
+float temperature = 0.0;           // current temperature in Celsius
+float Dewpoint = 0.0;              // current dewpoint in Celsius
+float Humidity = 0.0;              // current humidity in percent
+float Pressure = 0.0;              // current pressure in hPa
+#endif
 
+static String mqttBaseTopic;
+static String topicPublishSetValueW;
+static String topicPublishCalculatedValueW;
+static String topicPublishGridImportW;
+#if FEATURE_BME280_ENABLED
+static String topicPublishTempC;
+static String topicPublishHumidityPct;
+static String topicPublishDewpointC;
+#endif
+
+// Scheduler/timing state
+#if FEATURE_BME280_ENABLED
+static bool bme280Initialized = false;
+static volatile bool rs485TickDue = false;
+static unsigned long nextTemperatureReadMs = 0;
+static constexpr unsigned long MIN_TEMPERATURE_READ_INTERVAL_MS = 1000UL;
+static constexpr unsigned long MAX_TEMPERATURE_READ_INTERVAL_MS = 3600000UL;
+#else
+static volatile bool rs485TickDue = false;
+#endif
+
+#if FEATURE_OLED_DISPLAY_ENABLED
+// Display state
 bool displayActive = true; // flag to indicate if the display is active
 static bool displayInitialized = false;
-static bool bme280Initialized = false;
-#if FEATURE_HEATER_ENABLED
+static unsigned long nextDisplayRefreshMs = 0;
+static unsigned long displayOffAtMs = 0;
+static constexpr unsigned long DISPLAY_REFRESH_INTERVAL_MS = 1000UL;
+static constexpr unsigned long MIN_DISPLAY_ON_MS = 1000UL;
+static constexpr unsigned long MAX_DISPLAY_ON_MS = 86400000UL;
+#endif
+
+// Feature-specific globals
+#if FEATURE_HEATER_ENABLED && FEATURE_BME280_ENABLED
 static bool dewpointRiskActive = false;   // tracks dewpoint alarm state
+#endif
+#if FEATURE_HEATER_ENABLED
 static bool heaterLatchedState = false;   // hysteresis latch for heater
 #endif
 #if FEATURE_ANY_RELAY_OUTPUTS
@@ -304,25 +426,6 @@ static cm::MQTTManager::Settings &mqttSettings = mqtt.settings();
 static cm::IOManager ioManager;
 static cm::AlarmManager alarmManager;
 
-LimiterSettings limiterSettings;
-TempSettings tempSettings;
-I2CSettings i2cSettings;
-#if FEATURE_FAN_ENABLED
-FanSettings fanSettings;
-#endif
-#if FEATURE_HEATER_ENABLED
-HeaterSettings heaterSettings;
-#endif
-DisplaySettings displaySettings;
-WiFiRoamingSettings wifiRoamingSettings;
-RS485_Settings rs485settings;
-
-static cm::CoreSettings &coreSettings = cm::CoreSettings::instance();
-static cm::CoreSystemSettings &systemSettings = coreSettings.system;
-static cm::CoreWiFiSettings &wifiSettings = coreSettings.wifi;
-static cm::CoreNtpSettings &ntpSettings = coreSettings.ntp;
-static cm::CoreWiFiServices wifiServices;
-
 #if FEATURE_FAN_ENABLED
 static constexpr char IO_FAN_ID[] = "fan_relay";
 #endif
@@ -331,14 +434,6 @@ static constexpr char IO_HEATER_ID[] = "heater_relay";
 #endif
 static constexpr char IO_RESET_ID[] = "reset_btn";
 static constexpr char IO_AP_ID[] = "ap_btn";
-
-static String mqttBaseTopic;
-static String topicPublishSetValueW;
-static String topicPublishCalculatedValueW;
-static String topicPublishGridImportW;
-static String topicPublishTempC;
-static String topicPublishHumidityPct;
-static String topicPublishDewpointC;
 
 struct PidControllerState
 {
@@ -351,6 +446,7 @@ struct PidControllerState
 
 static PidControllerState pidController;
 static bool lastLimiterModeWasPid = false;
+static int lastSmootherRequestedSize = -1;
 static int lastNegativePriceOverrideTarget = -1;
 static NegativePriceSettingPreference lastNegativePriceSettingPreference = NegativePriceSettingPreference::None;
 static bool normalizingNegativePriceSettings = false;
@@ -405,16 +501,22 @@ void setup()
 
     updateMqttTopics();
     setupGUI();
+#if FEATURE_OLED_DISPLAY_ENABLED
     SetupStartDisplay();
     ShowDisplayOn();
+#endif
 
     cm::helpers::pulseWait(LED_BUILTIN, cm::helpers::PulseOutput::ActiveLevel::ActiveHigh, 3, 100);
 
-    powerSmoother = new Smoother(limiterSettings.smoothingSize.get());
-    powerSmoother->fillBufferOnStart(currentGridImportW);
+    if (!limiterSettings.usePidSmoothing.get())
+    {
+        ensurePowerSmoother(currentGridImportW);
+    }
 
     RS485begin();
+#if FEATURE_BME280_ENABLED
     SetupStartTemperatureMeasuring();
+#endif
 
     RS485Ticker.attach(limiterSettings.RS232PublishPeriod.get(), cb_RS485Listener);
 
@@ -461,6 +563,12 @@ void loop()
     ConfigManager.getWiFiManager().update();
     mqtt.loop();
     publishMqttNow();
+    handleRS485Scheduler();
+#if FEATURE_BME280_ENABLED
+    const bool temperatureUpdated = handleTemperatureScheduler();
+#else
+    const bool temperatureUpdated = false;
+#endif
     lmg.loop();
     ioManager.update();
 
@@ -471,10 +579,13 @@ void loop()
     updateStatusLED();
     cm::helpers::PulseOutput::loopAll();
 
-    WriteToDisplay();
+#if FEATURE_OLED_DISPLAY_ENABLED
+    handleDisplayScheduler();
+    handleDisplayPowerScheduler();
+#endif
 
 #if FEATURE_ANY_RELAY_OUTPUTS
-    if (!manualOverrideActive)
+    if (temperatureUpdated && !manualOverrideActive)
     {
 #if FEATURE_FAN_ENABLED
         CheckVentilator(temperature);
@@ -493,10 +604,14 @@ void setupGUI()
     // coreSettings owns the WiFi/System/NTP pages now; MQTT module registers its own layout.
     ConfigManager.addSettingsPage("Limiter", 60);
     ConfigManager.addSettingsGroup("Limiter", "Limiter", "Limiter Settings", 60);
+#if FEATURE_BME280_ENABLED
     ConfigManager.addSettingsPage("Temp", 70);
     ConfigManager.addSettingsGroup("Temp", "Temp", "Temp Settings", 70);
+#endif
+#if FEATURE_ANY_I2C
     ConfigManager.addSettingsPage("I2C", 80);
     ConfigManager.addSettingsGroup("I2C", "I2C", "I2C Settings", 80);
+#endif
 #if FEATURE_FAN_ENABLED
     ConfigManager.addSettingsPage("Fan", 90);
     ConfigManager.addSettingsGroup("Fan", "Fan", "Fan Settings", 90);
@@ -505,14 +620,17 @@ void setupGUI()
     ConfigManager.addSettingsPage("Heater", 100);
     ConfigManager.addSettingsGroup("Heater", "Heater", "Heater Settings", 100);
 #endif
+#if FEATURE_OLED_DISPLAY_ENABLED
     ConfigManager.addSettingsPage("Display", 110);
     ConfigManager.addSettingsGroup("Display", "Display", "Display Settings", 110);
+#endif
     ConfigManager.addSettingsPage("RS485", 120);
     ConfigManager.addSettingsGroup("RS485", "RS485", "RS485 Settings", 120);
     ConfigManager.addSettingsPage("I/O", 130);
     ConfigManager.addSettingsGroup("I/O", "I/O", "I/O Settings", 130);
 
     // region sensor fields BME280
+#if FEATURE_BME280_ENABLED
     auto sensors = ConfigManager.liveGroup("sensors")
                        .page("Limiter", 10)
                        .card("Sensors", 10)
@@ -545,6 +663,7 @@ void setupGUI()
         .unit("hPa")
         .precision(1)
         .order(13);
+#endif
     // endregion sensor fields
 
     // region Limiter
@@ -629,7 +748,7 @@ void setupGUI()
         .order(1);
 #endif
 
-#if FEATURE_HEATER_ENABLED
+#if FEATURE_HEATER_ENABLED && FEATURE_BME280_ENABLED
     outputs.stateButton(
                "heater",
                "Heater Relay Active",
@@ -667,6 +786,18 @@ void setupGUI()
               dewpointRiskActive = false;
               lmg.logTag(LL::Info, "ALARM", "Dewpoint risk EXIT");
               EvaluateHeater(temperature); });
+#elif FEATURE_HEATER_ENABLED
+    outputs.stateButton(
+               "heater",
+               "Heater Relay Active",
+               []()
+               { return getHeaterRelay(); },
+               [](bool on)
+               { setHeaterRelay(on); },
+               getHeaterRelay(),
+               "On",
+               "Off")
+        .order(2);
 #endif
 #endif
     // endregion relay outputs
@@ -701,17 +832,21 @@ static void setupLogging()
     Serial.begin(115200);
 
     auto serialOut = std::make_unique<cm::LoggingManager::SerialOutput>(Serial);
-    serialOut->setLevel(LL::Info);
+    serialOut->setLevel(LL::Off);
+    // serialOut->setLevel(LL::Info);
+    // serialOut->setLevel(LL::Debug);
     serialOut->addTimestamp(cm::LoggingManager::Output::TimestampMode::DateTime);
     serialOut->setRateLimitMs(2);
     lmg.addOutput(std::move(serialOut));
 
-    lmg.setGlobalLevel(LL::Info);
-    lmg.attachToConfigManager(LL::Info, LL::Info, "");
+    // lmg.setGlobalLevel(LL::Info);
+    lmg.setGlobalLevel(LL::Debug);
+    lmg.attachToConfigManager(LL::Info, LL::Debug, "");
 
-    auto guiOut = std::make_unique<cm::LoggingManager::GuiOutput>(ConfigManager, 50);
+    auto guiOut = std::make_unique<cm::LoggingManager::GuiOutput>(ConfigManager, 20);
     guiOut->addTimestamp(cm::LoggingManager::Output::TimestampMode::DateTime);
-    guiOut->setLevel(LL::Info);
+    // guiOut->setLevel(LL::Info);
+    guiOut->setLevel(LL::Debug);
     lmg.addOutput(std::move(guiOut));
 }
 
@@ -743,8 +878,11 @@ static void registerIOBindings()
         cm::IOManager::DigitalInputEventCallbacks{
             .onPress = []()
             {
+#if FEATURE_OLED_DISPLAY_ENABLED
                 lmg.logTag(LL::Debug, "IO", "Reset button pressed -> show display");
-                ShowDisplayOn(); },
+                ShowDisplayOn();
+#endif
+            },
             .onLongPressOnStartup = []()
             {
                 lmg.logTag(LL::Warn, "IO", "Reset button pressed at startup -> restoring defaults");
@@ -762,8 +900,11 @@ static void registerIOBindings()
         cm::IOManager::DigitalInputEventCallbacks{
             .onPress = []()
             {
+#if FEATURE_OLED_DISPLAY_ENABLED
                 lmg.logTag(LL::Debug, "IO", "AP button pressed -> show display");
-                ShowDisplayOn(); },
+                ShowDisplayOn();
+#endif
+            },
             .onLongPressOnStartup = []()
             {
                 lmg.logTag(LL::Warn, "IO", "AP button pressed at startup -> starting AP mode");
@@ -854,29 +995,32 @@ static void setupMqtt()
     // Optional: show receive topics in runtime UI
     // mqtt.addMqttTopicToLiveGroup(ConfigManager, "grid_import_w", "mqtt", "MQTT-Received", "MQTT-Received", 1);
 
-    static bool mqttLogAdded = false;
-    if (!mqttLogAdded)
-    {
-        auto mqttLog = std::make_unique<cm::MQTTLogOutput>(mqtt);
-        mqttLog->setLevel(LL::Info);
-        mqttLog->addTimestamp(cm::LoggingManager::Output::TimestampMode::DateTime);
-        lmg.addOutput(std::move(mqttLog));
-        mqttLogAdded = true;
-    }
+#if FEATURE_MQTT_LOGGER_ENABLED
+    auto mqttLog = std::make_unique<cm::MQTTLogOutput>(mqtt);
+    mqttLog->setLevel(LL::Info);
+    mqttLog->addTimestamp(cm::LoggingManager::Output::TimestampMode::DateTime);
+    lmg.addOutput(std::move(mqttLog));
+#endif
 }
 
 static void registerProjectSettings()
 {
     limiterSettings.attachTo(ConfigManager);
+#if FEATURE_BME280_ENABLED
     tempSettings.attachTo(ConfigManager);
+#endif
+#if FEATURE_ANY_I2C
     i2cSettings.attachTo(ConfigManager);
+#endif
 #if FEATURE_FAN_ENABLED
     fanSettings.attachTo(ConfigManager);
 #endif
 #if FEATURE_HEATER_ENABLED
     heaterSettings.attachTo(ConfigManager);
 #endif
+#if FEATURE_OLED_DISPLAY_ENABLED
     displaySettings.attachTo(ConfigManager);
+#endif
     wifiRoamingSettings.attachTo(ConfigManager);
     rs485settings.attachTo(ConfigManager);
 }
@@ -1179,13 +1323,39 @@ static void updateMqttTopics()
         base = APP_NAME;
     }
 
+    if (base == mqttBaseTopic)
+    {
+        return;
+    }
+
     mqttBaseTopic = base;
     topicPublishSetValueW = mqttBaseTopic + "/SetValue";
     topicPublishCalculatedValueW = mqttBaseTopic + "/CalculatedValue";
     topicPublishGridImportW = mqttBaseTopic + "/GetValue";
+#if FEATURE_BME280_ENABLED
     topicPublishTempC = mqttBaseTopic + "/Temperature";
     topicPublishHumidityPct = mqttBaseTopic + "/Humidity";
     topicPublishDewpointC = mqttBaseTopic + "/Dewpoint";
+#endif
+}
+
+static void publishMqttNow()
+{
+    if (!mqtt.isConnected())
+    {
+        return;
+    }
+
+    updateMqttTopics();
+
+    mqtt.publishExtraTopicLazy("setvalue_w", topicPublishSetValueW.c_str(), []() { return String(inverterSetValue); }, false);
+    mqtt.publishExtraTopicLazy("calculated_w", topicPublishCalculatedValueW.c_str(), []() { return String(inverterCalculatedValue); }, false);
+    mqtt.publishExtraTopicLazy("grid_import_w", topicPublishGridImportW.c_str(), []() { return String(currentGridImportW); }, false);
+#if FEATURE_BME280_ENABLED
+    mqtt.publishExtraTopicLazy("temperature_c", topicPublishTempC.c_str(), []() { return String(temperature); }, false);
+    mqtt.publishExtraTopicLazy("humidity_pct", topicPublishHumidityPct.c_str(), []() { return String(Humidity); }, false);
+    mqtt.publishExtraTopicLazy("dewpoint_c", topicPublishDewpointC.c_str(), []() { return String(Dewpoint); }, false);
+#endif
 }
 
 static void resetPidController()
@@ -1247,6 +1417,520 @@ static int computePidStabilizedTarget(int baseTarget, int configuredMin, int con
     return static_cast<int>(roundf(pidController.output));
 }
 
+//----------------------------------------
+// MQTT FUNCTIONS
+//----------------------------------------
+
+static unsigned long secondsToMsClamped(int seconds, unsigned long minMs, unsigned long maxMs)
+{
+    if (seconds <= 0)
+    {
+        return minMs;
+    }
+    const unsigned long secondsValue = static_cast<unsigned long>(seconds);
+    if (secondsValue > maxMs / 1000UL)
+    {
+        return maxMs;
+    }
+    const unsigned long ms = secondsValue * 1000UL;
+    if (ms < minMs)
+    {
+        return minMs;
+    }
+    if (ms > maxMs)
+    {
+        return maxMs;
+    }
+    return ms;
+}
+
+static bool timeReached(unsigned long now, unsigned long target)
+{
+    return target == 0 || static_cast<long>(now - target) >= 0;
+}
+
+static bool ensurePowerSmoother(int initialValue)
+{
+    if (powerSmoother != nullptr)
+    {
+        if (!powerSmoother->isReady())
+        {
+            delete powerSmoother;
+            powerSmoother = nullptr;
+        }
+        else
+        {
+            return true;
+        }
+    }
+
+    const int requestedSize = limiterSettings.smoothingSize.get();
+    powerSmoother = new (std::nothrow) Smoother(requestedSize);
+    if (powerSmoother == nullptr || !powerSmoother->isReady())
+    {
+        delete powerSmoother;
+        powerSmoother = nullptr;
+        lastSmootherRequestedSize = -1;
+        lmg.logTag(LL::Warn, "SMOOTH", "Buffer allocation failed");
+        return false;
+    }
+
+    lastSmootherRequestedSize = requestedSize;
+    powerSmoother->fillBufferOnStart(initialValue);
+    return true;
+}
+
+static bool updatePowerSmootherSizeIfNeeded(int initialValue)
+{
+    if (!ensurePowerSmoother(initialValue) || powerSmoother == nullptr)
+    {
+        return false;
+    }
+
+    const int requestedSize = limiterSettings.smoothingSize.get();
+    if (requestedSize == lastSmootherRequestedSize)
+    {
+        return powerSmoother->isReady();
+    }
+
+    const int previousSize = powerSmoother->size();
+    powerSmoother->setBufferSize(requestedSize);
+    lastSmootherRequestedSize = requestedSize;
+    if (powerSmoother->size() != previousSize)
+    {
+        powerSmoother->fillBufferOnStart(initialValue);
+    }
+
+    return powerSmoother->isReady();
+}
+
+static void handleRS485Scheduler()
+{
+    if (!rs485TickDue)
+    {
+        return;
+    }
+
+    rs485TickDue = false;
+    processRS485Tick();
+}
+
+#if FEATURE_BME280_ENABLED
+static bool handleTemperatureScheduler()
+{
+    if (!bme280Initialized)
+    {
+        return false;
+    }
+
+    const unsigned long now = millis();
+    if (!timeReached(now, nextTemperatureReadMs))
+    {
+        return false;
+    }
+
+    const unsigned long intervalMs = secondsToMsClamped(tempSettings.readIntervalSec.get(),
+                                                        MIN_TEMPERATURE_READ_INTERVAL_MS,
+                                                        MAX_TEMPERATURE_READ_INTERVAL_MS);
+    nextTemperatureReadMs = now + intervalMs;
+    return readBme280();
+}
+#endif
+
+static void updateStatusLED()
+{
+    static int lastMode = -1; // 1=AP, 2=CONNECTED, 3=CONNECTING
+
+    const bool connected = ConfigManager.getWiFiManager().isConnected();
+    const bool apMode = ConfigManager.getWiFiManager().isInAPMode();
+
+    const int mode = apMode ? 1 : (connected ? 2 : 3);
+    if (mode == lastMode)
+    {
+        return;
+    }
+    lastMode = mode;
+
+    switch (mode)
+    {
+    case 1: // AP mode: fast blink
+        buildinLED.setPulseRepeat(/*count*/ 1, /*periodMs*/ 200, /*gapMs*/ 0);
+        break;
+    case 2: // Connected: heartbeat
+        buildinLED.setPulseRepeat(/*count*/ 1, /*periodMs*/ 100, /*gapMs*/ 1500);
+        break;
+    case 3: // Connecting/disconnected: double blink
+        buildinLED.setPulseRepeat(/*count*/ 3, /*periodMs*/ 200, /*gapMs*/ 600);
+        break;
+    }
+}
+
+//----------------------------------------
+// HELPER FUNCTIONS
+//----------------------------------------
+
+void cb_RS485Listener()
+{
+    rs485TickDue = true;
+}
+
+static void processRS485Tick()
+{
+    int configuredMin = limiterSettings.minOutput.get();
+    int configuredMax = limiterSettings.maxOutput.get();
+    if (configuredMin > configuredMax)
+    {
+        const int tmp = configuredMin;
+        configuredMin = configuredMax;
+        configuredMax = tmp;
+    }
+
+    const bool usePidSmoothing = limiterSettings.usePidSmoothing.get();
+    if (usePidSmoothing != lastLimiterModeWasPid)
+    {
+        resetPidController();
+        if (!usePidSmoothing && ensurePowerSmoother(currentGridImportW))
+        {
+            powerSmoother->fillBufferOnStart(currentGridImportW);
+        }
+        lastLimiterModeWasPid = usePidSmoothing;
+    }
+
+    if (!usePidSmoothing)
+    {
+        updatePowerSmootherSizeIfNeeded(currentGridImportW);
+    }
+
+    const int offset = limiterSettings.inputCorrectionOffset.get();
+    const int currentInverterOutputW = solarPowerW;
+    const int signedGridPowerW = currentGridImportW;
+    const int gridImportW = max(signedGridPowerW, 0);
+    const int gridExportW = max(-signedGridPowerW, 0);
+    const bool negativePriceForceMinEnabled = limiterSettings.forceMinOnNegativePrice.get();
+    const bool negativePriceSetZeroEnabled = !negativePriceForceMinEnabled && limiterSettings.setZeroOnNegativePrice.get();
+    const bool negativePriceMinActive = negativePriceActive && negativePriceForceMinEnabled;
+    const bool negativePriceZeroActive = negativePriceActive && negativePriceSetZeroEnabled;
+    const int negativePriceOverrideTarget = negativePriceZeroActive ? 0 : (negativePriceMinActive ? configuredMin : -1);
+    if (negativePriceOverrideTarget != lastNegativePriceOverrideTarget)
+    {
+        if (negativePriceOverrideTarget >= 0)
+        {
+            lmg.logTag(LL::Info, "PRICE", "Negative price active (%.3f EUR/kWh) -> forcing %d W", electricityPriceEurKwh, negativePriceOverrideTarget);
+        }
+        else
+        {
+            lmg.logTag(LL::Info, "PRICE", "Negative price inactive (%.3f EUR/kWh) -> resuming normal output path", electricityPriceEurKwh);
+        }
+        lastNegativePriceOverrideTarget = negativePriceOverrideTarget;
+    }
+    int pidBaseTarget = 0;
+    int pidClampedBaseTarget = 0;
+    int pidInput = 0;
+
+    if (negativePriceOverrideTarget >= 0)
+    {
+        resetPidController();
+        inverterCalculatedValue = negativePriceOverrideTarget;
+    }
+    else if (usePidSmoothing)
+    {
+        pidBaseTarget = currentInverterOutputW + signedGridPowerW + offset;
+        pidClampedBaseTarget = constrain(pidBaseTarget, configuredMin, configuredMax);
+        pidInput = pidController.initialized ? static_cast<int>(roundf(pidController.output)) : pidClampedBaseTarget;
+        inverterCalculatedValue = computePidStabilizedTarget(pidBaseTarget, configuredMin, configuredMax);
+    }
+    else if (powerSmoother != nullptr && powerSmoother->isReady())
+    {
+        inverterCalculatedValue = powerSmoother->smooth(currentGridImportW);
+    }
+    else
+    {
+        inverterCalculatedValue = configuredMax;
+        lmg.logTag(LL::Warn, "RS485", "Smoother not initialized -> fallback to MAX");
+    }
+
+    if (negativePriceOverrideTarget >= 0)
+    {
+        inverterSetValue = negativePriceOverrideTarget;
+        sendToRS485(static_cast<uint16_t>(inverterSetValue));
+    }
+    else if (limiterSettings.enableController.get())
+    {
+        const int correctedValue = usePidSmoothing ? inverterCalculatedValue : inverterCalculatedValue + offset;
+        inverterSetValue = constrain(correctedValue, configuredMin, configuredMax);
+        sendToRS485(static_cast<uint16_t>(inverterSetValue));
+        lmg.logTag(LL::Trace, "RS485", "Controller enabled -> set inverter to %d W (calc=%d, corr=%d)", inverterSetValue, inverterCalculatedValue, correctedValue);
+        if (usePidSmoothing)
+        {
+            lmg.logTag(LL::Trace, "PID", "inv=%d gridSigned=%d gridIn=%d gridOut=%d off=%d base=%d clamp=%d in=%d out=%d min=%d max=%d set=%d",
+                       currentInverterOutputW, signedGridPowerW, gridImportW, gridExportW, offset, pidBaseTarget, pidClampedBaseTarget,
+                       pidInput, inverterCalculatedValue, configuredMin, configuredMax, inverterSetValue);
+        }
+    }
+    else
+    {
+        inverterSetValue = configuredMax;
+        resetPidController();
+        lmg.logTag(LL::Info, "RS485", "Controller disabled -> using MAX output");
+        sendToRS485(static_cast<uint16_t>(inverterSetValue));
+    }
+}
+
+void testRS232()
+{
+    // test the RS232 connection
+    lmg.logTag(LL::Info, "RS485", "Testing RS232 connection... shorting RX and TX pins");
+    lmg.logTag(LL::Info, "RS485", "Baudrate: %d", rs485settings.baudRate.get());
+    lmg.logTag(LL::Info, "RS485", "RX Pin: %d", rs485settings.rxPin.get());
+    lmg.logTag(LL::Info, "RS485", "TX Pin: %d", rs485settings.txPin.get());
+    lmg.logTag(LL::Info, "RS485", "DE Pin: %d", rs485settings.dePin.get());
+
+    Serial2.begin(rs485settings.baudRate.get(), SERIAL_8N1, rs485settings.rxPin.get(), rs485settings.txPin.get());
+    Serial2.println("Hello RS485");
+    delay(300);
+    if (Serial2.available())
+    {
+        lmg.logTag(LL::Debug, "RS485", "[MAIN] Received on Serial2");
+    }
+}
+
+#if FEATURE_BME280_ENABLED
+void SetupStartTemperatureMeasuring()
+{
+    // init BME280 for temperature and humidity sensor
+    bme280.setAddress(BME280_ADDRESS, i2cSettings.sdaPin.get(), i2cSettings.sclPin.get());
+    bool isStatus = bme280.begin(
+        bme280.BME280_STANDBY_0_5,
+        bme280.BME280_FILTER_16,
+        bme280.BME280_SPI3_DISABLE,
+        bme280.BME280_OVERSAMPLING_2,
+        bme280.BME280_OVERSAMPLING_16,
+        bme280.BME280_OVERSAMPLING_1,
+        bme280.BME280_MODE_NORMAL);
+    if (!isStatus)
+    {
+        bme280Initialized = false;
+        lmg.logTag(LL::Error, "BME280", "BME280 init failed");
+    }
+    else
+    {
+        bme280Initialized = true;
+        lmg.logTag(LL::Info, "BME280", "BME280 ready. Starting measurement scheduler...");
+
+        readBme280();
+        nextTemperatureReadMs = millis() + secondsToMsClamped(tempSettings.readIntervalSec.get(),
+                                                              MIN_TEMPERATURE_READ_INTERVAL_MS,
+                                                              MAX_TEMPERATURE_READ_INTERVAL_MS);
+    }
+}
+#endif
+
+void onWiFiConnected()
+{
+    wifiServices.onConnected(ConfigManager, APP_NAME, systemSettings, ntpSettings);
+    logNetworkIpInfo("onWiFiConnected");
+    lmg.logTag(LL::Debug, "WiFi", "Station Mode: http://%s", WiFi.localIP().toString().c_str());
+}
+
+void onWiFiDisconnected()
+{
+    wifiServices.onDisconnected();
+    lmg.logTag(LL::Warn, "WiFi", "Disconnected");
+}
+
+void onWiFiAPMode()
+{
+    wifiServices.onAPMode();
+    logNetworkIpInfo("onWiFiAPMode");
+    lmg.logTag(LL::Debug, "WiFi", "AP Mode: http://%s", WiFi.softAPIP().toString().c_str());
+}
+
+#if FEATURE_BME280_ENABLED
+bool readBme280()
+{
+    if (!bme280Initialized)
+    {
+        lmg.logTag(LL::Warn, "BME280", "Skip read: sensor not initialized");
+        return false;
+    }
+
+    // todo: add settings for correcting the values!!!
+    //   set sea-level pressure
+    bme280.setSeaLevelPressure(tempSettings.seaLevelPressure.get());
+
+    bme280.read();
+
+    const float measuredTemperature = bme280.data.temperature + tempSettings.tempCorrection.get();
+    const float measuredHumidity = bme280.data.humidity + tempSettings.humidityCorrection.get();
+    const float measuredPressure = bme280.data.pressure;
+
+    const bool temperatureValid = isfinite(measuredTemperature) && measuredTemperature >= -20.0f && measuredTemperature <= 70.0f;
+    const bool humidityValid = isfinite(measuredHumidity) && measuredHumidity >= 0.0f && measuredHumidity <= 100.0f;
+    const bool pressureValid = isfinite(measuredPressure) && measuredPressure >= 300.0f && measuredPressure <= 1200.0f;
+
+    if (!temperatureValid || !humidityValid || !pressureValid)
+    {
+        lmg.logTag(LL::Warn, "BME280", "Invalid read T=%.1f H=%.1f P=%.1f -> keep last", measuredTemperature, measuredHumidity, measuredPressure);
+        return false;
+    }
+
+    temperature = measuredTemperature;
+    Humidity = measuredHumidity;
+    Pressure = measuredPressure;
+    Dewpoint = cm::helpers::computeDewPoint(temperature, Humidity);
+
+    // output formatted values to serial console
+    lmg.logTag(LL::Trace, "BME280", "-----------------------");
+    lmg.logTag(LL::Trace, "BME280", "Temperature: %.1f C", temperature);
+    lmg.logTag(LL::Trace, "BME280", "Humidity   : %.1f %%", Humidity);
+    lmg.logTag(LL::Trace, "BME280", "Dewpoint   : %.1f C", Dewpoint);
+    lmg.logTag(LL::Trace, "BME280", "Pressure   : %.0f hPa", Pressure);
+    lmg.logTag(LL::Trace, "BME280", "Altitude   : %.2f m", bme280.data.altitude);
+    lmg.logTag(LL::Trace, "BME280", "-----------------------");
+    return true;
+}
+#endif
+
+// Limiter provider moved into setup() for clarity
+
+#if FEATURE_OLED_DISPLAY_ENABLED
+static void handleDisplayScheduler()
+{
+    const unsigned long now = millis();
+    if (!timeReached(now, nextDisplayRefreshMs))
+    {
+        return;
+    }
+
+    nextDisplayRefreshMs = now + DISPLAY_REFRESH_INTERVAL_MS;
+    WriteToDisplay();
+}
+
+static void handleDisplayPowerScheduler()
+{
+    if (!displayActive || !displaySettings.turnDisplayOff.get() || displayOffAtMs == 0)
+    {
+        return;
+    }
+
+    const unsigned long now = millis();
+    if (timeReached(now, displayOffAtMs))
+    {
+        ShowDisplayOff();
+    }
+}
+
+void SetupStartDisplay()
+{
+    Wire.begin(i2cSettings.sdaPin.get(), i2cSettings.sclPin.get());
+    Wire.setClock(i2cSettings.busFreq.get());
+
+    const uint8_t address = static_cast<uint8_t>(i2cSettings.displayAddr.get());
+    if (!display.begin(SSD1306_SWITCHCAPVCC, address))
+    {
+        displayInitialized = false;
+        displayActive = false;
+        lmg.logTag(LL::Warn, "Display", "SSD1306 init failed (addr=0x%02X)", static_cast<unsigned int>(address));
+        return;
+    }
+
+    displayInitialized = true;
+    displayActive = true;
+
+    display.clearDisplay();
+    display.drawRect(0, 0, 128, 25, WHITE);
+    display.setTextSize(2);
+    display.setTextColor(WHITE);
+    display.setCursor(10, 5);
+    display.println("Starting!");
+    display.display();
+}
+
+void WriteToDisplay()
+{
+    if (!displayInitialized || !displayActive)
+    {
+        return; // exit the function if the display is not active
+    }
+
+    // display.clearDisplay();
+    display.fillRect(0, 0, 128, 24, BLACK); // Clear the previous message area
+    display.drawRect(0, 0, 128, 24, WHITE);
+
+    display.setTextSize(1);
+    display.setTextColor(WHITE);
+
+    // When running in AP mode, show connection info prominently.
+    if (WiFi.getMode() == WIFI_AP && WiFi.status() != WL_CONNECTED)
+    {
+        const IPAddress apIp = WiFi.softAPIP();
+        const String apSsid = WiFi.softAPSSID();
+
+        display.setCursor(3, 3);
+        display.printf("AP: %s", apIp.toString().c_str());
+        display.setCursor(3, 13);
+        display.printf("SSID: %s", apSsid.c_str());
+        display.display();
+        return;
+    }
+
+    display.setCursor(3, 3);
+#if FEATURE_BME280_ENABLED
+    if (temperature > 0)
+    {
+        display.printf("<- %d W|Temp: %2.1f", currentGridImportW, temperature);
+    }
+    else
+    {
+        display.printf("<- %d W", currentGridImportW);
+    }
+
+    display.setCursor(3, 13);
+    if (Dewpoint != 0)
+    {
+        display.printf("-> %d W|DP-T: %2.1f", inverterSetValue, Dewpoint);
+    }
+    else
+    {
+        display.printf("-> %d W", inverterSetValue);
+    }
+#else
+    display.printf("<- %d W", currentGridImportW);
+
+    display.setCursor(3, 13);
+    display.printf("-> %d W", inverterSetValue);
+#endif
+
+    display.display();
+}
+
+void ShowDisplayOn()
+{
+    if (!displayInitialized)
+        return;
+    display.ssd1306_command(SSD1306_DISPLAYON); // Turn on the display
+    displayActive = true;
+    displayOffAtMs = millis() + secondsToMsClamped(displaySettings.onTimeSec.get(),
+                                                   MIN_DISPLAY_ON_MS,
+                                                   MAX_DISPLAY_ON_MS);
+    nextDisplayRefreshMs = 0;
+}
+
+void ShowDisplayOff()
+{
+    if (!displayInitialized)
+        return;
+    display.ssd1306_command(SSD1306_DISPLAYOFF); // Turn off the display
+    // display.fillRect(0, 0, 128, 24, BLACK); // Clear the previous message area
+
+    if (displaySettings.turnDisplayOff.get())
+    {
+        displayActive = false;
+    }
+    displayOffAtMs = 0;
+}
+#endif
+
 #if FEATURE_FAN_ENABLED
 static void setFanRelay(bool on)
 {
@@ -1299,348 +1983,6 @@ static void setManualOverride(bool on)
 }
 #endif
 
-//----------------------------------------
-// MQTT FUNCTIONS
-//----------------------------------------
-
-static void publishMqttNow()
-{
-    if (!mqtt.isConnected())
-    {
-        return;
-    }
-
-    updateMqttTopics();
-
-    mqtt.publishExtraTopic("setvalue_w", topicPublishSetValueW.c_str(), String(inverterSetValue), false);
-    mqtt.publishExtraTopic("calculated_w", topicPublishCalculatedValueW.c_str(), String(inverterCalculatedValue), false);
-    mqtt.publishExtraTopic("grid_import_w", topicPublishGridImportW.c_str(), String(currentGridImportW), false);
-    mqtt.publishExtraTopic("temperature_c", topicPublishTempC.c_str(), String(temperature), false);
-    mqtt.publishExtraTopic("humidity_pct", topicPublishHumidityPct.c_str(), String(Humidity), false);
-    mqtt.publishExtraTopic("dewpoint_c", topicPublishDewpointC.c_str(), String(Dewpoint), false);
-}
-
-static void updateStatusLED()
-{
-    static int lastMode = -1; // 1=AP, 2=CONNECTED, 3=CONNECTING
-
-    const bool connected = ConfigManager.getWiFiManager().isConnected();
-    const bool apMode = ConfigManager.getWiFiManager().isInAPMode();
-
-    const int mode = apMode ? 1 : (connected ? 2 : 3);
-    if (mode == lastMode)
-    {
-        return;
-    }
-    lastMode = mode;
-
-    switch (mode)
-    {
-    case 1: // AP mode: fast blink
-        buildinLED.setPulseRepeat(/*count*/ 1, /*periodMs*/ 200, /*gapMs*/ 0);
-        break;
-    case 2: // Connected: heartbeat
-        buildinLED.setPulseRepeat(/*count*/ 1, /*periodMs*/ 100, /*gapMs*/ 1500);
-        break;
-    case 3: // Connecting/disconnected: double blink
-        buildinLED.setPulseRepeat(/*count*/ 3, /*periodMs*/ 200, /*gapMs*/ 600);
-        break;
-    }
-}
-
-//----------------------------------------
-// HELPER FUNCTIONS
-//----------------------------------------
-
-void cb_RS485Listener()
-{
-    int configuredMin = limiterSettings.minOutput.get();
-    int configuredMax = limiterSettings.maxOutput.get();
-    if (configuredMin > configuredMax)
-    {
-        const int tmp = configuredMin;
-        configuredMin = configuredMax;
-        configuredMax = tmp;
-    }
-
-    if (powerSmoother != nullptr)
-    {
-        powerSmoother->setBufferSize(limiterSettings.smoothingSize.get());
-    }
-
-    const bool usePidSmoothing = limiterSettings.usePidSmoothing.get();
-    if (usePidSmoothing != lastLimiterModeWasPid)
-    {
-        resetPidController();
-        if (powerSmoother != nullptr)
-        {
-            powerSmoother->fillBufferOnStart(currentGridImportW);
-        }
-        lastLimiterModeWasPid = usePidSmoothing;
-    }
-
-    const int offset = limiterSettings.inputCorrectionOffset.get();
-    const int currentInverterOutputW = solarPowerW;
-    const int signedGridPowerW = currentGridImportW;
-    const int gridImportW = max(signedGridPowerW, 0);
-    const int gridExportW = max(-signedGridPowerW, 0);
-    const bool negativePriceForceMinEnabled = limiterSettings.forceMinOnNegativePrice.get();
-    const bool negativePriceSetZeroEnabled = !negativePriceForceMinEnabled && limiterSettings.setZeroOnNegativePrice.get();
-    const bool negativePriceMinActive = negativePriceActive && negativePriceForceMinEnabled;
-    const bool negativePriceZeroActive = negativePriceActive && negativePriceSetZeroEnabled;
-    const int negativePriceOverrideTarget = negativePriceZeroActive ? 0 : (negativePriceMinActive ? configuredMin : -1);
-    if (negativePriceOverrideTarget != lastNegativePriceOverrideTarget)
-    {
-        if (negativePriceOverrideTarget >= 0)
-        {
-            lmg.logTag(LL::Info, "PRICE", "Negative price active (%.3f EUR/kWh) -> forcing %d W", electricityPriceEurKwh, negativePriceOverrideTarget);
-        }
-        else
-        {
-            lmg.logTag(LL::Info, "PRICE", "Negative price inactive (%.3f EUR/kWh) -> resuming normal output path", electricityPriceEurKwh);
-        }
-        lastNegativePriceOverrideTarget = negativePriceOverrideTarget;
-    }
-    int pidBaseTarget = 0;
-    int pidClampedBaseTarget = 0;
-    int pidInput = 0;
-
-    if (negativePriceOverrideTarget >= 0)
-    {
-        resetPidController();
-        inverterCalculatedValue = negativePriceOverrideTarget;
-    }
-    else if (usePidSmoothing)
-    {
-        pidBaseTarget = currentInverterOutputW + signedGridPowerW + offset;
-        pidClampedBaseTarget = constrain(pidBaseTarget, configuredMin, configuredMax);
-        pidInput = pidController.initialized ? static_cast<int>(roundf(pidController.output)) : pidClampedBaseTarget;
-        inverterCalculatedValue = computePidStabilizedTarget(pidBaseTarget, configuredMin, configuredMax);
-    }
-    else if (powerSmoother != nullptr)
-    {
-        inverterCalculatedValue = powerSmoother->smooth(currentGridImportW);
-    }
-    else
-    {
-        inverterCalculatedValue = configuredMax;
-        lmg.logTag(LL::Warn, "RS485", "Smoother not initialized -> fallback to MAX");
-    }
-
-    if (negativePriceOverrideTarget >= 0)
-    {
-        inverterSetValue = negativePriceOverrideTarget;
-        sendToRS485(static_cast<uint16_t>(inverterSetValue));
-    }
-    else if (limiterSettings.enableController.get())
-    {
-        const int correctedValue = usePidSmoothing ? inverterCalculatedValue : inverterCalculatedValue + offset;
-        inverterSetValue = constrain(correctedValue, configuredMin, configuredMax);
-        sendToRS485(static_cast<uint16_t>(inverterSetValue));
-        lmg.logTag(LL::Trace, "RS485", "Controller enabled -> set inverter to %d W (calc=%d, corr=%d)", inverterSetValue, inverterCalculatedValue, correctedValue);
-        if (usePidSmoothing)
-        {
-            lmg.logTag(LL::Debug, "PID", "inv=%d gridSigned=%d gridIn=%d gridOut=%d off=%d base=%d clamp=%d in=%d out=%d min=%d max=%d set=%d",
-                       currentInverterOutputW, signedGridPowerW, gridImportW, gridExportW, offset, pidBaseTarget, pidClampedBaseTarget,
-                       pidInput, inverterCalculatedValue, configuredMin, configuredMax, inverterSetValue);
-        }
-    }
-    else
-    {
-        inverterSetValue = configuredMax;
-        resetPidController();
-        lmg.logTag(LL::Info, "RS485", "Controller disabled -> using MAX output");
-        sendToRS485(static_cast<uint16_t>(inverterSetValue));
-    }
-}
-
-void testRS232()
-{
-    // test the RS232 connection
-    lmg.logTag(LL::Info, "RS485", "Testing RS232 connection... shorting RX and TX pins");
-    lmg.logTag(LL::Info, "RS485", "Baudrate: %d", rs485settings.baudRate.get());
-    lmg.logTag(LL::Info, "RS485", "RX Pin: %d", rs485settings.rxPin.get());
-    lmg.logTag(LL::Info, "RS485", "TX Pin: %d", rs485settings.txPin.get());
-    lmg.logTag(LL::Info, "RS485", "DE Pin: %d", rs485settings.dePin.get());
-
-    Serial2.begin(rs485settings.baudRate.get(), SERIAL_8N1, rs485settings.rxPin.get(), rs485settings.txPin.get());
-    Serial2.println("Hello RS485");
-    delay(300);
-    if (Serial2.available())
-    {
-        lmg.logTag(LL::Debug, "RS485", "[MAIN] Received on Serial2");
-    }
-}
-
-void SetupStartDisplay()
-{
-    Wire.begin(i2cSettings.sdaPin.get(), i2cSettings.sclPin.get());
-    Wire.setClock(i2cSettings.busFreq.get());
-
-    const uint8_t address = static_cast<uint8_t>(i2cSettings.displayAddr.get());
-    if (!display.begin(SSD1306_SWITCHCAPVCC, address))
-    {
-        displayInitialized = false;
-        displayActive = false;
-        lmg.logTag(LL::Warn, "Display", "SSD1306 init failed (addr=0x%02X)", static_cast<unsigned int>(address));
-        return;
-    }
-
-    displayInitialized = true;
-    displayActive = true;
-
-    display.clearDisplay();
-    display.drawRect(0, 0, 128, 25, WHITE);
-    display.setTextSize(2);
-    display.setTextColor(WHITE);
-    display.setCursor(10, 5);
-    display.println("Starting!");
-    display.display();
-}
-
-void SetupStartTemperatureMeasuring()
-{
-    // init BME280 for temperature and humidity sensor
-    bme280.setAddress(BME280_ADDRESS, i2cSettings.sdaPin.get(), i2cSettings.sclPin.get());
-    bool isStatus = bme280.begin(
-        bme280.BME280_STANDBY_0_5,
-        bme280.BME280_FILTER_16,
-        bme280.BME280_SPI3_DISABLE,
-        bme280.BME280_OVERSAMPLING_2,
-        bme280.BME280_OVERSAMPLING_16,
-        bme280.BME280_OVERSAMPLING_1,
-        bme280.BME280_MODE_NORMAL);
-    if (!isStatus)
-    {
-        bme280Initialized = false;
-        lmg.logTag(LL::Error, "BME280", "BME280 init failed");
-    }
-    else
-    {
-        bme280Initialized = true;
-        lmg.logTag(LL::Info, "BME280", "BME280 ready. Starting measurement ticker...");
-
-        temperatureTicker.attach(tempSettings.readIntervalSec.get(), readBme280); // Attach the ticker to read BME280
-        readBme280();                                                             // initial read
-    }
-}
-
-void onWiFiConnected()
-{
-    wifiServices.onConnected(ConfigManager, APP_NAME, systemSettings, ntpSettings);
-    logNetworkIpInfo("onWiFiConnected");
-    lmg.logTag(LL::Debug, "WiFi", "Station Mode: http://%s", WiFi.localIP().toString().c_str());
-}
-
-void onWiFiDisconnected()
-{
-    wifiServices.onDisconnected();
-    lmg.logTag(LL::Warn, "WiFi", "Disconnected");
-}
-
-void onWiFiAPMode()
-{
-    wifiServices.onAPMode();
-    logNetworkIpInfo("onWiFiAPMode");
-    lmg.logTag(LL::Debug, "WiFi", "AP Mode: http://%s", WiFi.softAPIP().toString().c_str());
-}
-
-void readBme280()
-{
-    if (!bme280Initialized)
-    {
-        lmg.logTag(LL::Warn, "BME280", "Skip read: sensor not initialized");
-        return;
-    }
-
-    // todo: add settings for correcting the values!!!
-    //   set sea-level pressure
-    bme280.setSeaLevelPressure(tempSettings.seaLevelPressure.get());
-
-    bme280.read();
-
-    const float measuredTemperature = bme280.data.temperature + tempSettings.tempCorrection.get();
-    const float measuredHumidity = bme280.data.humidity + tempSettings.humidityCorrection.get();
-    const float measuredPressure = bme280.data.pressure;
-
-    const bool temperatureValid = isfinite(measuredTemperature) && measuredTemperature >= -20.0f && measuredTemperature <= 70.0f;
-    const bool humidityValid = isfinite(measuredHumidity) && measuredHumidity >= 0.0f && measuredHumidity <= 100.0f;
-    const bool pressureValid = isfinite(measuredPressure) && measuredPressure >= 300.0f && measuredPressure <= 1200.0f;
-
-    if (!temperatureValid || !humidityValid || !pressureValid)
-    {
-        lmg.logTag(LL::Warn, "BME280", "Invalid read T=%.1f H=%.1f P=%.1f -> keep last", measuredTemperature, measuredHumidity, measuredPressure);
-        return;
-    }
-
-    temperature = measuredTemperature;
-    Humidity = measuredHumidity;
-    Pressure = measuredPressure;
-    Dewpoint = cm::helpers::computeDewPoint(temperature, Humidity);
-
-    // output formatted values to serial console
-    lmg.logTag(LL::Trace, "BME280", "-----------------------");
-    lmg.logTag(LL::Trace, "BME280", "Temperature: %.1f C", temperature);
-    lmg.logTag(LL::Trace, "BME280", "Humidity   : %.1f %%", Humidity);
-    lmg.logTag(LL::Trace, "BME280", "Dewpoint   : %.1f C", Dewpoint);
-    lmg.logTag(LL::Trace, "BME280", "Pressure   : %.0f hPa", Pressure);
-    lmg.logTag(LL::Trace, "BME280", "Altitude   : %.2f m", bme280.data.altitude);
-    lmg.logTag(LL::Trace, "BME280", "-----------------------");
-}
-
-// Limiter provider moved into setup() for clarity
-
-void WriteToDisplay()
-{
-    if (!displayInitialized || !displayActive)
-    {
-        return; // exit the function if the display is not active
-    }
-
-    // display.clearDisplay();
-    display.fillRect(0, 0, 128, 24, BLACK); // Clear the previous message area
-    display.drawRect(0, 0, 128, 24, WHITE);
-
-    display.setTextSize(1);
-    display.setTextColor(WHITE);
-
-    // When running in AP mode, show connection info prominently.
-    if (WiFi.getMode() == WIFI_AP && WiFi.status() != WL_CONNECTED)
-    {
-        const IPAddress apIp = WiFi.softAPIP();
-        const String apSsid = WiFi.softAPSSID();
-
-        display.setCursor(3, 3);
-        display.printf("AP: %s", apIp.toString().c_str());
-        display.setCursor(3, 13);
-        display.printf("SSID: %s", apSsid.c_str());
-        display.display();
-        return;
-    }
-
-    display.setCursor(3, 3);
-    if (temperature > 0)
-    {
-        display.printf("<- %d W|Temp: %2.1f", currentGridImportW, temperature);
-    }
-    else
-    {
-        display.printf("<- %d W", currentGridImportW);
-    }
-
-    display.setCursor(3, 13);
-    if (Dewpoint != 0)
-    {
-        display.printf("-> %d W|DP-T: %2.1f", inverterSetValue, Dewpoint);
-    }
-    else
-    {
-        display.printf("-> %d W", inverterSetValue);
-    }
-
-    display.display();
-}
-
 #if FEATURE_FAN_ENABLED
 void CheckVentilator(float currentTemperature)
 {
@@ -1677,10 +2019,12 @@ void EvaluateHeater(float currentTemperature)
     }
 #endif
 
+#if FEATURE_BME280_ENABLED
     if (dewpointRiskActive)
     {
         heaterLatchedState = true;
     }
+#endif
 
     if (heaterSettings.enabled.get())
     {
@@ -1703,26 +2047,3 @@ void EvaluateHeater(float currentTemperature)
 }
 #endif
 
-void ShowDisplayOn()
-{
-    if (!displayInitialized)
-        return;
-    displayTicker.detach();                                                // Stop the ticker to prevent multiple calls
-    display.ssd1306_command(SSD1306_DISPLAYON);                            // Turn on the display
-    displayTicker.attach(displaySettings.onTimeSec.get(), ShowDisplayOff); // Reattach the ticker to turn off the display after the specified time
-    displayActive = true;
-}
-
-void ShowDisplayOff()
-{
-    if (!displayInitialized)
-        return;
-    displayTicker.detach();                      // Stop the ticker to prevent multiple calls
-    display.ssd1306_command(SSD1306_DISPLAYOFF); // Turn off the display
-    // display.fillRect(0, 0, 128, 24, BLACK); // Clear the previous message area
-
-    if (displaySettings.turnDisplayOff.get())
-    {
-        displayActive = false;
-    }
-}


### PR DESCRIPTION
## Summary
- make the SolarInverterLimiter BME280 path optional like the OLED path
- add the ota_no_oled_no_bme validation environment
- document the new example build variant and changelog impact

## Validation
- pio run -e usb
- pio run -e ota
- pio run -e ota_no_oled_no_bme