### PR TITLE
Update ESP32 Configuration Manager to 4.2.2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -37,7 +37,7 @@ lib_deps =
 	adafruit/Adafruit BusIO@^1.17.4
 	bblanchon/ArduinoJson@7.4.3
 	esphome/ESPAsyncWebServer-esphome@^3.4.0
-	vitaly.ruhl/ESP32 Configuration Manager@^4.2.0
+	vitaly.ruhl/ESP32 Configuration Manager@^4.2.2
 	;symlink://C:/Daten/_Codding/ESP32/ConfigurationsManager
 test_ignore = src/main.cpp
 extra_scripts =
@@ -65,7 +65,7 @@ lib_deps =
 	adafruit/Adafruit BusIO@^1.17.4
 	bblanchon/ArduinoJson@7.4.3
 	esphome/ESPAsyncWebServer-esphome@^3.4.0
-	vitaly.ruhl/ESP32 Configuration Manager@^4.2.0
+	vitaly.ruhl/ESP32 Configuration Manager@^4.2.2
 	;symlink://C:/Daten/_Codding/ESP32/ConfigurationsManager
 test_ignore = src/main.cpp
 extra_scripts =

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ This project is an ESP32-based solar inverter limiter that can be used to limit 
 
 ## ConfigManager v4 note
 
-- This project is aligned to `ESP32 Configuration Manager` `v4.x` (currently `^4.0.0` in `platformio.ini`).
+- This project is aligned to `ESP32 Configuration Manager` `v4.x` (currently `^4.2.2` in `platformio.ini`).
 - The pre-build step uses `tools/precompile_wrapper.py`.
 - The wrapper delegates to the library script inside `.pio/libdeps/<env>/ESP32 Configuration Manager/tools/preCompile_script.py`.
 - This keeps WebUI/header generation in sync with the installed ConfigManager library version.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,7 +95,7 @@
 #endif
 
 #ifndef VERSION
-#define VERSION "4.3.0"
+#define VERSION "4.3.1"
 #endif
 
 enum class NegativePriceSettingPreference : uint8_t


### PR DESCRIPTION
## Summary
- update ESP32 Configuration Manager from 4.2.0 to 4.2.2
- bump firmware version from 4.3.0 to 4.3.1
- synchronize the README dependency note

## Validation
- pio run -e usb
- pio run -e ota

Both builds resolved ESP32 Configuration Manager 4.2.2 successfully.